### PR TITLE
feat(validation): implement validators for Nino and Persona DTOs (#3)

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -2,6 +2,7 @@ using FluentValidation;
 using FluentValidation.AspNetCore;
 using KindergartenAPI.Data;
 using KindergartenAPI.Routes;
+using KindergartenAPI.Validators;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.OpenApi.Models;
 
@@ -28,8 +29,10 @@ builder.Services.AddSwaggerGen(c =>
 builder.Services.AddAutoMapper(typeof(Program).Assembly); // Registrando AutoMapper
 
 // Agregando FluentValidation
-builder.Services.AddFluentValidationAutoValidation()
-.AddValidatorsFromAssemblyContaining<Program>();
+builder.Services
+    .AddFluentValidationAutoValidation()
+    .AddFluentValidationClientsideAdapters()
+    .AddValidatorsFromAssemblyContaining<Program>();
 
 var app = builder.Build();
 

--- a/Validators/NinoCreateDtoValidator.cs
+++ b/Validators/NinoCreateDtoValidator.cs
@@ -1,0 +1,26 @@
+using FluentValidation;
+using KindergartenAPI.DTOs.Ninos;
+
+namespace KindergartenAPI.Validators
+{
+    public class NinoCreateDtoValidator : AbstractValidator<NinoCreateDto>
+    {
+        public NinoCreateDtoValidator()
+        {
+            RuleFor(n => n.Nombre)
+                .NotEmpty().WithMessage("El nombre es obligatorio.")
+                .MaximumLength(100).WithMessage("El nombre no puede exceder los 100 caracteres.");
+
+            RuleFor(n => n.FechaNacimiento)
+                .NotEmpty().WithMessage("La fecha de nacimiento es obligatoria.")
+                .LessThan(DateTime.Now).WithMessage("La fecha de nacimiento debe ser anterior a la fecha actual.");
+
+            RuleFor(n => n.FechaIngreso)
+                .NotEmpty().WithMessage("La fecha de ingreso es obligatoria.")
+                .GreaterThanOrEqualTo(n => n.FechaNacimiento).WithMessage("La fecha de ingreso debe ser igual o posterior a la fecha de nacimiento.");
+
+            RuleFor(n => n.CedulaPagador)
+                .NotEmpty().WithMessage("La cédula del pagador es obligatoria.");
+        }
+    }
+}

--- a/Validators/NinoUpdateDtoValidator.cs
+++ b/Validators/NinoUpdateDtoValidator.cs
@@ -1,0 +1,27 @@
+using FluentValidation;
+using KindergartenAPI.DTOs.Ninos;
+
+namespace KindergartenAPI.Validators
+{
+    public class NinoUpdateDtoValidator : AbstractValidator<NinoUpdateDto>
+    {
+        public NinoUpdateDtoValidator()
+        {
+            RuleFor(x => x.Nombre)
+                .NotEmpty().WithMessage("El nombre es obligatorio.")
+                .MaximumLength(100).WithMessage("El nombre no puede exceder 100 caracteres.");
+
+            RuleFor(x => x.FechaNacimiento)
+                .LessThan(DateOnly.FromDateTime(DateTime.Today))
+                .WithMessage("La fecha de nacimiento debe ser anterior a hoy.");
+
+            RuleFor(x => x.FechaIngreso)
+                .LessThanOrEqualTo(DateOnly.FromDateTime(DateTime.Today))
+                .WithMessage("La fecha de ingreso no puede ser en el futuro.");
+
+            RuleFor(x => x.CedulaPagador)
+                .NotEmpty()
+                .WithMessage("La cédula del pagador es obligatoria.");
+        }
+    }
+}

--- a/Validators/PersonaCreateDtoValidators.cs
+++ b/Validators/PersonaCreateDtoValidators.cs
@@ -1,0 +1,27 @@
+using FluentValidation;
+using KindergartenAPI.DTOs.Personas;
+
+namespace KindergartenAPI.Validators
+{
+    public class PersonaCreateDtoValidator : AbstractValidator<PersonaCreateDto>
+    {
+        public PersonaCreateDtoValidator()
+        {
+            RuleFor(x => x.Cedula)
+                .NotEmpty()
+                .WithMessage("La cédula es obligatoria.");
+
+            RuleFor(x => x.Nombre)
+                .NotEmpty().WithMessage("El nombre es obligatorio.")
+                .MaximumLength(100).WithMessage("El nombre no puede exceder 100 caracteres.");
+
+            RuleFor(x => x.Direccion)
+                .NotEmpty().WithMessage("La dirección es obligatoria.")
+                .MaximumLength(200).WithMessage("La dirección no puede exceder 200 caracteres.");
+
+            RuleFor(x => x.Telefono)
+                .NotEmpty().WithMessage("El teléfono es obligatorio.")
+                .Matches("^[0-9]{7,10}$").WithMessage("El teléfono debe tener entre 7 y 10 dígitos.");
+        }
+    }
+}

--- a/Validators/PersonaUpdateDtoValidators.cs
+++ b/Validators/PersonaUpdateDtoValidators.cs
@@ -1,0 +1,23 @@
+using FluentValidation;
+using KindergartenAPI.DTOs.Personas;
+
+namespace KindergartenAPI.Validators
+{
+public class PersonaUpdateDtoValidator : AbstractValidator<PersonaUpdateDto>
+    {
+        public PersonaUpdateDtoValidator()
+        {
+            RuleFor(x => x.Nombre)
+                .NotEmpty().WithMessage("El nombre es obligatorio.")
+                .MaximumLength(100).WithMessage("El nombre no puede exceder 100 caracteres.");
+
+            RuleFor(x => x.Direccion)
+                .NotEmpty().WithMessage("La dirección es obligatoria.")
+                .MaximumLength(200).WithMessage("La dirección no puede exceder 200 caracteres.");
+
+            RuleFor(x => x.Telefono)
+                .NotEmpty().WithMessage("El teléfono es obligatorio.")
+                .Matches("^[0-9]{7,10}$").WithMessage("El teléfono debe tener entre 7 y 10 dígitos.");
+        }
+    }
+}


### PR DESCRIPTION
This PR adds FluentValidation validators for the following DTOs:

- `NinoCreateDto` and `NinoUpdateDto`
- `PersonaCreateDto` and `PersonaUpdateDto`

Each validator enforces business rules (e.g. non-empty fields, date constraints, numerical checks).

Closes #3 
