### PR TITLE
feat(nino): switch to DateOnly for date fields and update validation rules

### DIFF
--- a/backend/KindergartenAPI/DTOs/NinoDTOs.cs
+++ b/backend/KindergartenAPI/DTOs/NinoDTOs.cs
@@ -5,11 +5,11 @@ using KindergartenAPI.DTOs.Personas;
 public class NinoCreateDto
 {
     public string Nombre { get; set; } = null!;
-    public DateTime FechaNacimiento { get; set; }
+    public DateOnly FechaNacimiento { get; set; }
 
-    public DateTime FechaIngreso { get; set; }
+    public DateOnly FechaIngreso { get; set; }
 
-    public int CedulaPagador { get; set; }
+    public string CedulaPagador { get; set; } = null!;
 }
 
 public class NinoReadDto

--- a/backend/KindergartenAPI/Validators/NinoCreateDtoValidator.cs
+++ b/backend/KindergartenAPI/Validators/NinoCreateDtoValidator.cs
@@ -13,11 +13,18 @@ namespace KindergartenAPI.Validators
 
             RuleFor(n => n.FechaNacimiento)
                 .NotEmpty().WithMessage("La fecha de nacimiento es obligatoria.")
-                .LessThan(DateTime.Now).WithMessage("La fecha de nacimiento debe ser anterior a la fecha actual.");
+                .Must(fecha => fecha.ToDateTime(TimeOnly.MinValue) < DateTime.Now)
+                .WithMessage("La fecha de nacimiento debe ser anterior a la fecha actual.");
+
+            RuleFor(x => x.FechaNacimiento)
+                .LessThan(x => x.FechaIngreso)
+                .WithMessage("La fecha de nacimiento debe ser anterior a la fecha de ingreso.")
+                .When(x => x.FechaNacimiento.ToDateTime(TimeOnly.MinValue) < DateTime.Now); // only if nacimiento is valid when compare to fecha actual
 
             RuleFor(n => n.FechaIngreso)
                 .NotEmpty().WithMessage("La fecha de ingreso es obligatoria.")
-                .GreaterThanOrEqualTo(n => n.FechaNacimiento).WithMessage("La fecha de ingreso debe ser igual o posterior a la fecha de nacimiento.");
+                .Must((nino, fechaIngreso) => fechaIngreso >= nino.FechaNacimiento)
+                .WithMessage("La fecha de ingreso debe ser igual o posterior a la fecha de nacimiento.");
 
             RuleFor(n => n.CedulaPagador)
                 .NotEmpty().WithMessage("La cédula del pagador es obligatoria.");

--- a/backend/KindergartenAPI/Validators/NinoUpdateDtoValidator.cs
+++ b/backend/KindergartenAPI/Validators/NinoUpdateDtoValidator.cs
@@ -15,9 +15,20 @@ namespace KindergartenAPI.Validators
                 .LessThan(DateOnly.FromDateTime(DateTime.Today))
                 .WithMessage("La fecha de nacimiento debe ser anterior a hoy.");
 
+            RuleFor(x => x.FechaNacimiento)
+                .LessThan(x => x.FechaIngreso)
+                .WithMessage("La fecha de nacimiento debe ser anterior a la fecha de ingreso.")
+                .When(x => x.FechaNacimiento.ToDateTime(TimeOnly.MinValue) < DateTime.Now); // only if nacimiento is valid when compare to fecha actual
+
             RuleFor(x => x.FechaIngreso)
                 .LessThanOrEqualTo(DateOnly.FromDateTime(DateTime.Today))
                 .WithMessage("La fecha de ingreso no puede ser en el futuro.");
+
+            RuleFor(x => x.FechaBaja)
+                .GreaterThan(x => x.FechaIngreso)
+                .When(x => x.FechaBaja.HasValue)
+                .WithMessage("La fecha de baja debe ser posterior a la fecha de ingreso.");
+
 
             RuleFor(x => x.CedulaPagador)
                 .NotEmpty()


### PR DESCRIPTION
### Cambios realizados
- Se cambió el tipo de dato de las fechas en el modelo de niño a `DateOnly`.
- Se actualizaron las reglas de validación:
  - La fecha de nacimiento no puede ser futura.
  - La fecha de nacimiento debe ser anterior a la de ingreso.
  - La fecha de baja (cuando aplica) no puede ser anterior a la de ingreso.

### Motivación
Esto mejora la precisión de las fechas y evita problemas relacionados a horas no deseadas en la lógica del dominio.
