### PR TITLE
feat(persona): integrate persona list view with API

### DIFF
--- a/frontend/src/api/axios.ts
+++ b/frontend/src/api/axios.ts
@@ -1,0 +1,8 @@
+import axios from 'axios';
+
+export const api = axios.create({
+  baseURL: `${import.meta.env.VITE_API_URL || 'http://localhost:5214'}/api/v1`,
+  headers: {
+    'Content-Type': 'application/json',
+  },
+});

--- a/frontend/src/api/persona.ts
+++ b/frontend/src/api/persona.ts
@@ -1,22 +1,15 @@
-import axios from 'axios';
-import type { PersonaReadDto, PersonaCreateDto, PersonaUpdateDto } from './types';
+import { api } from './axios';
 
-export const API_URL = axios.create({
-  baseURL: import.meta.env.VITE_API_URL || 'http://localhost:5000',
-});
-
-export const api = axios.create({
-  baseURL: `${API_URL}/api/v1`,
-  headers: {
-    'Content-Type': 'application/json',
-  },
-});
+import type { PersonaReadDto, PersonaCreateDto, PersonaUpdateDto } from '../types/persona';
 
 // ————— Personas —————
 
 // Listar todas
 export const getPersonas = (): Promise<PersonaReadDto[]> =>
-  api.get('/personas').then((res) => res.data);
+  api.get('/personas').then((res) => {
+    console.log('Data received from API:', res);
+    return res.data;
+  });
 
 // Obtener una por cédula
 export const getPersona = (cedula: string): Promise<PersonaReadDto> =>

--- a/frontend/src/sections/persona/persona-table-row.tsx
+++ b/frontend/src/sections/persona/persona-table-row.tsx
@@ -16,13 +16,11 @@ import { Iconify } from 'src/components/iconify';
 // ----------------------------------------------------------------------
 
 export type PersonaProps = {
-  id: string;
-  name: string;
-  role: string;
-  status: string;
-  company: string;
+  cedula: string;
+  nombre: string;
+  telefono: string;
+  direccion: string;
   avatarUrl: string;
-  isVerified: boolean;
 };
 
 type PersonaTableRowProps = {
@@ -57,26 +55,14 @@ export function PersonaTableRow({ row, selected, onSelectRow }: PersonaTableRowP
               alignItems: 'center',
             }}
           >
-            <Avatar alt={row.name} src={row.avatarUrl} />
-            {row.name}
+            <Avatar alt={row.nombre} src={row.avatarUrl} />
+            {row.nombre}
           </Box>
         </TableCell>
 
-        <TableCell>{row.company}</TableCell>
-
-        <TableCell>{row.role}</TableCell>
-
-        <TableCell align="center">
-          {row.isVerified ? (
-            <Iconify width={22} icon="solar:check-circle-bold" sx={{ color: 'success.main' }} />
-          ) : (
-            '-'
-          )}
-        </TableCell>
-
-        <TableCell>
-          <Label color={(row.status === 'banned' && 'error') || 'success'}>{row.status}</Label>
-        </TableCell>
+        <TableCell>{row.cedula}</TableCell>
+        <TableCell>{row.telefono}</TableCell>
+        <TableCell>{row.direccion}</TableCell>
 
         <TableCell align="right">
           <IconButton onClick={handleOpenPopover}>

--- a/frontend/src/sections/persona/utils.ts
+++ b/frontend/src/sections/persona/utils.ts
@@ -71,7 +71,7 @@ export function applyFilter({ inputData, comparator, filterName }: ApplyFilterPr
 
   if (filterName) {
     inputData = inputData.filter(
-      (user) => user.name.toLowerCase().indexOf(filterName.toLowerCase()) !== -1
+      (user) => user.nombre.toLowerCase().indexOf(filterName.toLowerCase()) !== -1
     );
   }
 

--- a/frontend/src/types/persona.ts
+++ b/frontend/src/types/persona.ts
@@ -1,4 +1,3 @@
-
 export interface PersonaReadDto {
   cedula: string;
   nombre: string;


### PR DESCRIPTION
## 📌 Descripción

Este PR conecta la vista de lista de personas (`PersonaView`) con el backend usando Axios. Se reemplaza el mock estático por datos reales desde la API (`/api/v1/personas`).

## ✅ Cambios realizados

- Integración de Axios y configuración de baseURL vía `VITE_API_URL`.
- Creación del cliente Axios con endpoint versionado (`/api/v1`).
- Mapeo del `PersonaReadDto` al tipo `PersonaProps` que requiere la UI.
- Refactor de `PersonaView` para hacer fetch de datos reales.
- Se agregan placeholders para `avatarUrl`, `status`, `isVerified`, etc.
- Corrección de los tipos en `PersonaTableRow`.

## 📎 Notas adicionales

- El backend debe estar corriendo y habilitar CORS.
- Se utilizó `VITE_API_URL` en `.env` para facilitar entornos diferentes.
