### PR TITLE
feat(persona): enable editing existing personas from the table

### DIFF
--- a/frontend/src/sections/persona/persona-table-row.tsx
+++ b/frontend/src/sections/persona/persona-table-row.tsx
@@ -27,9 +27,10 @@ type PersonaTableRowProps = {
   row: PersonaProps;
   selected: boolean;
   onSelectRow: () => void;
+  onEdit: (persona: PersonaProps) => void;
 };
 
-export function PersonaTableRow({ row, selected, onSelectRow }: PersonaTableRowProps) {
+export function PersonaTableRow({ row, selected, onSelectRow, onEdit }: PersonaTableRowProps) {
   const [openPopover, setOpenPopover] = useState<HTMLButtonElement | null>(null);
 
   const handleOpenPopover = useCallback((event: React.MouseEvent<HTMLButtonElement>) => {
@@ -94,7 +95,12 @@ export function PersonaTableRow({ row, selected, onSelectRow }: PersonaTableRowP
             },
           }}
         >
-          <MenuItem onClick={handleClosePopover}>
+          <MenuItem
+            onClick={() => {
+              handleClosePopover();
+              onEdit(row); // <— pasar row al handler de edición
+            }}
+          >
             <Iconify icon="solar:pen-bold" />
             Edit
           </MenuItem>

--- a/frontend/src/sections/persona/view/persona-view.tsx
+++ b/frontend/src/sections/persona/view/persona-view.tsx
@@ -39,6 +39,47 @@ export function PersonaView() {
 
   const [loading, setLoading] = useState(true);
 
+  //Edit Persona
+  const [editPersona, setEditPersona] = useState<PersonaReadDto | null>(null);
+
+  // Dialog para crear una nueva persona
+  const [openDialog, setOpenDialog] = useState(false);
+
+  // Abrir diálogo para crear (editPersona = null)
+  function handleOpenCreate() {
+    setEditPersona(null);
+    setOpenDialog(true);
+  }
+
+  // Abrir diálogo para editar (editPersona = persona a editar)
+  function handleOpenEdit(persona: PersonaReadDto) {
+    setEditPersona(persona);
+    setOpenDialog(true);
+  }
+
+  // Cerrar diálogo
+  function handleCloseDialog() {
+    setOpenDialog(false);
+    setEditPersona(null);
+  }
+
+  const handleCreated = (newPersona: PersonaCreateDto) => {
+    // recarga o inserta en la lista local
+    setPersonas((prev) => [newPersona, ...prev]);
+    table.onResetPage();
+    handleCloseDialog();
+  };
+
+  function handleUpdated(updatedPersona: PersonaReadDto) {
+    // refrescar lista o hacer map sobre personas para actualizar la fila
+    setPersonas((arr) => arr.map((p) => (p.cedula === updatedPersona.cedula ? updatedPersona : p)));
+    handleCloseDialog();
+  }
+
+  // function handleEdit(p: PersonaReadDto) {
+  //   setEditPersona(p);
+  // }
+
   useEffect(() => {
     const fecthData = async () => {
       setLoading(true);
@@ -53,15 +94,6 @@ export function PersonaView() {
     };
     fecthData();
   }, []);
-
-  // Dialog para crear una nueva persona
-  const [openDialog, setOpenDialog] = useState(false);
-
-  const handleCreated = (newPersona: PersonaCreateDto) => {
-    // recarga o inserta en la lista local
-    setPersonas((prev) => [newPersona, ...prev]);
-    table.onResetPage();
-  };
 
   function mapDtoToProps(pers: PersonaReadDto[]): PersonaProps[] {
     if (!Array.isArray(pers)) {
@@ -109,8 +141,9 @@ export function PersonaView() {
 
       <PersonaFormDialog
         open={openDialog}
-        onClose={() => setOpenDialog(false)}
-        onCreated={handleCreated}
+        initial={editPersona ?? undefined}
+        onClose={handleCloseDialog}
+        onCreated={editPersona ? handleUpdated : handleCreated}
       />
 
       <Card>
@@ -158,6 +191,7 @@ export function PersonaView() {
                       row={row}
                       selected={table.selected.includes(row.cedula)}
                       onSelectRow={() => table.onSelectRow(row.cedula)}
+                      onEdit={() => handleOpenEdit(row)}
                     />
                   ))}
 


### PR DESCRIPTION
This PR adds the ability to edit existing personas directly from the table view using the shared `PersonaFormDialog` component. When a user clicks the edit button on a row, the dialog opens pre-filled with the selected persona's data. After saving, the list updates locally without requiring a full reload.

**Changes include:**
- Detecting edit mode by checking for `initial` props.
- Mapping the updated data back into the personas list on success.
- Unified dialog for both create and update operations.

This improves the UX by allowing in-place edits without leaving the page.
